### PR TITLE
fix: 'not assignable to the same property in base type' typescript 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "standard-version": "^9.0.0",
     "ts-node": "~9.0.0",
     "tslint": "~6.1.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.0.3"
   },
   "config": {
     "commitizen": {

--- a/projects/ngx-typesafe-forms/src/lib/form-array.ts
+++ b/projects/ngx-typesafe-forms/src/lib/form-array.ts
@@ -27,7 +27,10 @@ export class FormArray<T> extends AngularFormArray implements AbstractControl<T[
   public value!: T[];
   public valueChanges!: Observable<T[]>;
 
+  /* tslint:disable:variable-name */
   private _validator: ValidatorFn<T[]> | null = null;
+  private _asyncValidator: AsyncValidatorFn<T[]> | null = null;
+  /* tslint:enable:variable-name */
 
   public set validator(validator: ValidatorFn<T[]> | null) {
     this._validator = validator;
@@ -36,8 +39,6 @@ export class FormArray<T> extends AngularFormArray implements AbstractControl<T[
   public get validator(): ValidatorFn<T[]> | null {
     return this._validator;
   }
-
-  private _asyncValidator: AsyncValidatorFn<T[]> | null = null;
 
   public set asyncValidator(asyncValidator: AsyncValidatorFn<T[]> | null) {
     this._asyncValidator = asyncValidator;

--- a/projects/ngx-typesafe-forms/src/lib/form-array.ts
+++ b/projects/ngx-typesafe-forms/src/lib/form-array.ts
@@ -27,8 +27,25 @@ export class FormArray<T> extends AngularFormArray implements AbstractControl<T[
   public value!: T[];
   public valueChanges!: Observable<T[]>;
 
-  public validator!: ValidatorFn<T[]> | null;
-  public asyncValidator!: AsyncValidatorFn<T[]> | null;
+  private _validator: ValidatorFn<T[]> | null = null;
+
+  public set validator(validator: ValidatorFn<T[]> | null) {
+    this._validator = validator;
+  }
+
+  public get validator(): ValidatorFn<T[]> | null {
+    return this._validator;
+  }
+
+  private _asyncValidator: AsyncValidatorFn<T[]> | null = null;
+
+  public set asyncValidator(asyncValidator: AsyncValidatorFn<T[]> | null) {
+    this._asyncValidator = asyncValidator;
+  }
+
+  public get asyncValidator(): AsyncValidatorFn<T[]> | null {
+    return this._asyncValidator;
+  }
 
   constructor(
     public controls: AbstractControl<T>[],

--- a/projects/ngx-typesafe-forms/src/lib/form-control.ts
+++ b/projects/ngx-typesafe-forms/src/lib/form-control.ts
@@ -27,8 +27,25 @@ export class FormControl<T> extends AngularFormControl implements AbstractContro
   public value!: T;
   public valueChanges!: Observable<T>;
 
-  public validator!: ValidatorFn<T> | null;
-  public asyncValidator!: AsyncValidatorFn<T> | null;
+  private _validator: ValidatorFn<T> | null = null;
+
+  public set validator(validator: ValidatorFn<T> | null) {
+    this._validator = validator;
+  }
+
+  public get validator(): ValidatorFn<T> | null {
+    return this._validator;
+  }
+
+  private _asyncValidator: AsyncValidatorFn<T> | null = null;
+
+  public set asyncValidator(asyncValidator: AsyncValidatorFn<T> | null) {
+    this._asyncValidator = asyncValidator;
+  }
+
+  public get asyncValidator(): AsyncValidatorFn<T> | null {
+    return this._asyncValidator;
+  }
 
   constructor(
     formState?: T,

--- a/projects/ngx-typesafe-forms/src/lib/form-control.ts
+++ b/projects/ngx-typesafe-forms/src/lib/form-control.ts
@@ -27,7 +27,10 @@ export class FormControl<T> extends AngularFormControl implements AbstractContro
   public value!: T;
   public valueChanges!: Observable<T>;
 
+  /* tslint:disable:variable-name */
   private _validator: ValidatorFn<T> | null = null;
+  private _asyncValidator: AsyncValidatorFn<T> | null = null;
+  /* tslint:enable:variable-name */
 
   public set validator(validator: ValidatorFn<T> | null) {
     this._validator = validator;
@@ -36,8 +39,6 @@ export class FormControl<T> extends AngularFormControl implements AbstractContro
   public get validator(): ValidatorFn<T> | null {
     return this._validator;
   }
-
-  private _asyncValidator: AsyncValidatorFn<T> | null = null;
 
   public set asyncValidator(asyncValidator: AsyncValidatorFn<T> | null) {
     this._asyncValidator = asyncValidator;

--- a/projects/ngx-typesafe-forms/src/lib/form-group.ts
+++ b/projects/ngx-typesafe-forms/src/lib/form-group.ts
@@ -29,8 +29,25 @@ export class FormGroup<T> extends AngularFormGroup implements AbstractControl<T>
   public value!: T;
   public valueChanges!: Observable<T>;
 
-  public validator!: ValidatorFn<T> | null;
-  public asyncValidator!: AsyncValidatorFn<T> | null;
+  private _validator: ValidatorFn<T> | null = null;
+
+  public set validator(validator: ValidatorFn<T> | null) {
+    this._validator = validator;
+  }
+
+  public get validator(): ValidatorFn<T> | null {
+    return this._validator;
+  }
+
+  private _asyncValidator: AsyncValidatorFn<T> | null = null;
+
+  public set asyncValidator(asyncValidator: AsyncValidatorFn<T> | null) {
+    this._asyncValidator = asyncValidator;
+  }
+
+  public get asyncValidator(): AsyncValidatorFn<T> | null {
+    return this._asyncValidator;
+  }
 
   constructor(
     public controls: {

--- a/projects/ngx-typesafe-forms/src/lib/form-group.ts
+++ b/projects/ngx-typesafe-forms/src/lib/form-group.ts
@@ -29,7 +29,10 @@ export class FormGroup<T> extends AngularFormGroup implements AbstractControl<T>
   public value!: T;
   public valueChanges!: Observable<T>;
 
+  /* tslint:disable:variable-name */
   private _validator: ValidatorFn<T> | null = null;
+  private _asyncValidator: AsyncValidatorFn<T> | null = null;
+  /* tslint:enable:variable-name */
 
   public set validator(validator: ValidatorFn<T> | null) {
     this._validator = validator;
@@ -38,8 +41,6 @@ export class FormGroup<T> extends AngularFormGroup implements AbstractControl<T>
   public get validator(): ValidatorFn<T> | null {
     return this._validator;
   }
-
-  private _asyncValidator: AsyncValidatorFn<T> | null = null;
 
   public set asyncValidator(asyncValidator: AsyncValidatorFn<T> | null) {
     this._asyncValidator = asyncValidator;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11061,10 +11061,10 @@ typescript@4.0.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
   integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
-typescript@~3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@~4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 uglify-js@^3.1.4:
   version "3.10.2"


### PR DESCRIPTION
Ran into this error on typescript 4 and this fixes it for me. Let me know if anything's missing.
More info: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#properties-overriding-accessors-and-vice-versa-is-an-error