### PR TITLE
fix: dont create new observables each time

### DIFF
--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -3,6 +3,7 @@
 <p>
   <input type="text" [formControl]="formControls.name">
 </p>
-<p><code>value = {{ formControls.name.value | json }}</code></p>
-<p><code>valid = {{ formControls.name.valid | json }}</code></p>
-<p><code>errors = {{ formControls.name.errors | json }}</code></p>
+<p><code>value = {{ formControls.name.value | json }} {{ formControls.name.value$ | async | json }}</code></p>
+<p><code>valid = {{ formControls.name.valid | json }} {{ formControls.name.valid$ | async | json }}</code></p>
+<p><code>pristine = {{ formControls.name.pristine | json }} {{ formControls.name.pristine$ | async | json }}</code></p>
+<p><code>errors = {{ formControls.name.errors | json }} {{ formControls.name.errors$ | async | json }}</code></p>

--- a/projects/ngx-typesafe-forms/src/lib/form-array.ts
+++ b/projects/ngx-typesafe-forms/src/lib/form-array.ts
@@ -102,45 +102,25 @@ export class FormArray<T> extends AngularFormArray implements AbstractControl<T[
     return super.getRawValue();
   }
 
-  public get value$(): Observable<T[]> {
-    return formControlValue$(this);
-  }
+  public readonly value$: Observable<T> = formControlValue$(this);
 
-  public get errors$(): Observable<ValidationErrors | null> {
-    return formControlErrors$(this);
-  }
+  public readonly errors$: Observable<ValidationErrors | null> = formControlErrors$(this);
 
-  public get enabled$(): Observable<boolean> {
-    return formControlEnabled$(this);
-  }
+  public readonly enabled$: Observable<boolean> = formControlEnabled$(this);
 
-  public get pristine$(): Observable<boolean> {
-    return formControlPristine$(this);
-  }
+  public readonly pristine$: Observable<boolean> = formControlPristine$(this);
 
-  public get valid$(): Observable<boolean> {
-    return formControlValid$(this);
-  }
+  public readonly valid$: Observable<boolean> = formControlValid$(this);
 
-  public get status$(): Observable<FormStatus> {
-    return formControlStatus$(this);
-  }
+  public readonly status$: Observable<FormStatus> = formControlStatus$(this);
 
-  public get disabled$(): Observable<boolean> {
-    return abstractControlDisabled$(this);
-  }
+  public readonly disabled$: Observable<boolean> = abstractControlDisabled$(this);
 
-  public get dirty$(): Observable<boolean> {
-    return abstractControlDirty$(this);
-  }
+  public readonly dirty$: Observable<boolean> = abstractControlDirty$(this);
 
-  public get invalid$(): Observable<boolean> {
-    return formControlInvalid$(this);
-  }
+  public readonly invalid$: Observable<boolean> = formControlInvalid$(this);
 
-  public get validValue$(): Observable<T[]> {
-    return this.value$.pipe(filter(() => this.valid));
-  }
+  public readonly validValue$: Observable<T> = this.value$.pipe(filter(() => this.valid));
 
   public setEnabled(enabled: boolean = true): void {
     setEnabled(this, enabled);

--- a/projects/ngx-typesafe-forms/src/lib/form-control.ts
+++ b/projects/ngx-typesafe-forms/src/lib/form-control.ts
@@ -87,45 +87,25 @@ export class FormControl<T> extends AngularFormControl implements AbstractContro
     super.reset(formState, options);
   }
 
-  public get value$(): Observable<T> {
-    return formControlValue$(this);
-  }
+  public readonly value$: Observable<T> = formControlValue$(this);
 
-  public get errors$(): Observable<ValidationErrors | null> {
-    return formControlErrors$(this);
-  }
+  public readonly errors$: Observable<ValidationErrors | null> = formControlErrors$(this);
 
-  public get enabled$(): Observable<boolean> {
-    return formControlEnabled$(this);
-  }
+  public readonly enabled$: Observable<boolean> = formControlEnabled$(this);
 
-  public get pristine$(): Observable<boolean> {
-    return formControlPristine$(this);
-  }
+  public readonly pristine$: Observable<boolean> = formControlPristine$(this);
 
-  public get valid$(): Observable<boolean> {
-    return formControlValid$(this);
-  }
+  public readonly valid$: Observable<boolean> = formControlValid$(this);
 
-  public get status$(): Observable<FormStatus> {
-    return formControlStatus$(this);
-  }
+  public readonly status$: Observable<FormStatus> = formControlStatus$(this);
 
-  public get disabled$(): Observable<boolean> {
-    return abstractControlDisabled$(this);
-  }
+  public readonly disabled$: Observable<boolean> = abstractControlDisabled$(this);
 
-  public get dirty$(): Observable<boolean> {
-    return abstractControlDirty$(this);
-  }
+  public readonly dirty$: Observable<boolean> = abstractControlDirty$(this);
 
-  public get invalid$(): Observable<boolean> {
-    return formControlInvalid$(this);
-  }
+  public readonly invalid$: Observable<boolean> = formControlInvalid$(this);
 
-  public get validValue$(): Observable<T> {
-    return this.value$.pipe(filter(() => this.valid));
-  }
+  public readonly validValue$: Observable<T> = this.value$.pipe(filter(() => this.valid));
 
   public setEnabled(enabled: boolean = true): void {
     setEnabled(this, enabled);

--- a/projects/ngx-typesafe-forms/src/lib/form-group.ts
+++ b/projects/ngx-typesafe-forms/src/lib/form-group.ts
@@ -118,45 +118,25 @@ export class FormGroup<T> extends AngularFormGroup implements AbstractControl<T>
     return super.patchValue(value, options);
   }
 
-  public get value$(): Observable<T> {
-    return formControlValue$(this);
-  }
+  public readonly value$: Observable<T> = formControlValue$(this);
 
-  public get errors$(): Observable<ValidationErrors | null> {
-    return formControlErrors$(this);
-  }
+  public readonly errors$: Observable<ValidationErrors | null> = formControlErrors$(this);
 
-  public get enabled$(): Observable<boolean> {
-    return formControlEnabled$(this);
-  }
+  public readonly enabled$: Observable<boolean> = formControlEnabled$(this);
 
-  public get pristine$(): Observable<boolean> {
-    return formControlPristine$(this);
-  }
+  public readonly pristine$: Observable<boolean> = formControlPristine$(this);
 
-  public get valid$(): Observable<boolean> {
-    return formControlValid$(this);
-  }
+  public readonly valid$: Observable<boolean> = formControlValid$(this);
 
-  public get status$(): Observable<FormStatus> {
-    return formControlStatus$(this);
-  }
+  public readonly status$: Observable<FormStatus> = formControlStatus$(this);
 
-  public get disabled$(): Observable<boolean> {
-    return abstractControlDisabled$(this);
-  }
+  public readonly disabled$: Observable<boolean> = abstractControlDisabled$(this);
 
-  public get dirty$(): Observable<boolean> {
-    return abstractControlDirty$(this);
-  }
+  public readonly dirty$: Observable<boolean> = abstractControlDirty$(this);
 
-  public get invalid$(): Observable<boolean> {
-    return formControlInvalid$(this);
-  }
+  public readonly invalid$: Observable<boolean> = formControlInvalid$(this);
 
-  public get validValue$(): Observable<T> {
-    return this.value$.pipe(filter(() => this.valid));
-  }
+  public readonly validValue$: Observable<T> = this.value$.pipe(filter(() => this.valid));
 
   public setEnabled(enabled: boolean = true): void {
     setEnabled(this, enabled);


### PR DESCRIPTION
The getters were creating new observables each time, resulting in the same initial value from my previous PR being emitted. I think the code is working as intended with this change, as the defer() in the various factory functions manages the new subscriptions.